### PR TITLE
HelmInstaller: pick latest stable Helm by excluding prerelease/drafts

### DIFF
--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -720,12 +720,24 @@ export class ApplicationTokenCredentials {
         return deferred.promise;
     }
 
+    private _getOpenSSLPath() {
+        if (tl.osType().match(/^Win/)) {
+            if (tl.getPipelineFeature("UseOpenSSLv3.4.2InAzureArmRest")) {
+                return tl.which(path.join(__dirname, 'openssl3.4.2', 'openssl'));
+            } else {
+                return tl.which(path.join(__dirname, 'openssl3.4.0', 'openssl'));
+            }
+        } else {
+            return tl.which('openssl');
+        }
+    }
+
     /**
      * @deprecated ADAL related methods are deprecated and will be removed.
      * Use Use `getMSALToken(force?: boolean)` instead.
      */
     private _getSPNCertificateAuthorizationToken(): string {
-        var openSSLPath = tl.osType().match(/^Win/) ? tl.which(path.join(__dirname, 'openssl', 'openssl')) : tl.which('openssl');
+        var openSSLPath = this._getOpenSSLPath();
         var openSSLArgsArray = [
             "x509",
             "-sha1",
@@ -734,7 +746,7 @@ export class ApplicationTokenCredentials {
             this.certFilePath,
             "-fingerprint"
         ];
-
+        tl.debug(`The OpenSSL version is ${tl.execSync(openSSLPath, 'version')}`);
         var pemExecutionResult = tl.execSync(openSSLPath, openSSLArgsArray);
         var additionalHeaders = {
             "alg": "RS256",

--- a/common-npm-packages/azure-arm-rest/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest/azure-arm-common.ts
@@ -720,24 +720,12 @@ export class ApplicationTokenCredentials {
         return deferred.promise;
     }
 
-    private _getOpenSSLPath() {
-        if (tl.osType().match(/^Win/)) {
-            if (tl.getPipelineFeature("UseOpenSSLv3.4.2InAzureArmRest")) {
-                return tl.which(path.join(__dirname, 'openssl3.4.2', 'openssl'));
-            } else {
-                return tl.which(path.join(__dirname, 'openssl3.4.0', 'openssl'));
-            }
-        } else {
-            return tl.which('openssl');
-        }
-    }
-
     /**
      * @deprecated ADAL related methods are deprecated and will be removed.
      * Use Use `getMSALToken(force?: boolean)` instead.
      */
     private _getSPNCertificateAuthorizationToken(): string {
-        var openSSLPath = this._getOpenSSLPath();
+        var openSSLPath = tl.osType().match(/^Win/) ? tl.which(path.join(__dirname, 'openssl', 'openssl')) : tl.which('openssl');
         var openSSLArgsArray = [
             "x509",
             "-sha1",
@@ -746,7 +734,7 @@ export class ApplicationTokenCredentials {
             this.certFilePath,
             "-fingerprint"
         ];
-        tl.debug(`The OpenSSL version is ${tl.execSync(openSSLPath, 'version')}`);
+
         var pemExecutionResult = tl.execSync(openSSLPath, openSSLArgsArray);
         var additionalHeaders = {
             "alg": "RS256",

--- a/common-npm-packages/azure-arm-rest/make.js
+++ b/common-npm-packages/azure-arm-rest/make.js
@@ -1,8 +1,24 @@
+const tl = require('azure-pipelines-task-lib/task');
 var path = require('path');
 var util = require('../build-scripts/util');
-
+var fs = require('fs');
 var buildPath = './_build'
 
+var opensslLatestVersion = tl.getPipelineFeature('UseOpenSSLv3.4.2InAzureArmRest');
+var opensslDir;
+var opensslUrl;
+if (opensslLatestVersion) {
+	opensslDir = 'openssl3.4.2';
+	opensslUrl = 'https://vstsagenttools.blob.core.windows.net/tools/openssl/3.4.2/M262/openssl.zip';
+} 
+else {
+	opensslDir = 'openssl3.4.0';
+	opensslUrl = 'https://vstsagenttools.blob.core.windows.net/tools/openssl/3.4.0/M252/openssl.zip';
+}
+
+if (!fs.existsSync(path.join(__dirname, opensslDir))) {
+	util.run(`node ../build-scripts/downloadArchive.js ${opensslUrl} ${opensslDir}`);
+}
 util.rm('-rf', buildPath)
 util.run(path.join(__dirname, 'node_modules/.bin/tsc') + ' --outDir ' + buildPath);
 
@@ -11,6 +27,6 @@ util.cp(path.join(__dirname, 'package-lock.json'), buildPath);
 util.cp(path.join(__dirname, 'module.json'), buildPath);
 util.cp(path.join('./Tests', 'package.json'), path.join(buildPath, 'Tests'));
 util.cp(path.join('./Tests', 'package-lock.json'), path.join(buildPath, 'Tests'));
-util.cp('-r', 'openssl', buildPath);
+util.cp('-r', opensslDir, buildPath);
 util.cp('-r', 'Strings', buildPath);
 util.cp('-r', 'node_modules', buildPath);

--- a/common-npm-packages/azure-arm-rest/make.js
+++ b/common-npm-packages/azure-arm-rest/make.js
@@ -1,24 +1,8 @@
-import * as tl from 'azure-pipelines-task-lib/task';
 var path = require('path');
 var util = require('../build-scripts/util');
-var fs = require('fs');
+
 var buildPath = './_build'
 
-var opensslLatestVersion = tl.getPipelineFeature('UseOpenSSLv3.4.2InAzureArmRest');
-var opensslDir;
-var opensslUrl;
-if (opensslLatestVersion) {
-	opensslDir = 'openssl3.4.2';
-	opensslUrl = 'https://vstsagenttools.blob.core.windows.net/tools/openssl/3.4.2/M262/openssl.zip';
-} 
-else {
-	opensslDir = 'openssl3.4.0';
-	opensslUrl = 'https://vstsagenttools.blob.core.windows.net/tools/openssl/3.4.0/M252/openssl.zip';
-}
-
-if (!fs.existsSync(path.join(__dirname, opensslDir))) {
-	util.run(`node ../build-scripts/downloadArchive.js ${opensslUrl} ${opensslDir}`);
-}
 util.rm('-rf', buildPath)
 util.run(path.join(__dirname, 'node_modules/.bin/tsc') + ' --outDir ' + buildPath);
 
@@ -27,6 +11,6 @@ util.cp(path.join(__dirname, 'package-lock.json'), buildPath);
 util.cp(path.join(__dirname, 'module.json'), buildPath);
 util.cp(path.join('./Tests', 'package.json'), path.join(buildPath, 'Tests'));
 util.cp(path.join('./Tests', 'package-lock.json'), path.join(buildPath, 'Tests'));
-util.cp('-r', opensslDir, buildPath);
+util.cp('-r', 'openssl', buildPath);
 util.cp('-r', 'Strings', buildPath);
 util.cp('-r', 'node_modules', buildPath);

--- a/common-npm-packages/azure-arm-rest/make.js
+++ b/common-npm-packages/azure-arm-rest/make.js
@@ -1,8 +1,24 @@
+import * as tl from 'azure-pipelines-task-lib/task';
 var path = require('path');
 var util = require('../build-scripts/util');
-
+var fs = require('fs');
 var buildPath = './_build'
 
+var opensslLatestVersion = tl.getPipelineFeature('UseOpenSSLv3.4.2InAzureArmRest');
+var opensslDir;
+var opensslUrl;
+if (opensslLatestVersion) {
+	opensslDir = 'openssl3.4.2';
+	opensslUrl = 'https://vstsagenttools.blob.core.windows.net/tools/openssl/3.4.2/M262/openssl.zip';
+} 
+else {
+	opensslDir = 'openssl3.4.0';
+	opensslUrl = 'https://vstsagenttools.blob.core.windows.net/tools/openssl/3.4.0/M252/openssl.zip';
+}
+
+if (!fs.existsSync(path.join(__dirname, opensslDir))) {
+	util.run(`node ../build-scripts/downloadArchive.js ${opensslUrl} ${opensslDir}`);
+}
 util.rm('-rf', buildPath)
 util.run(path.join(__dirname, 'node_modules/.bin/tsc') + ' --outDir ' + buildPath);
 
@@ -11,6 +27,6 @@ util.cp(path.join(__dirname, 'package-lock.json'), buildPath);
 util.cp(path.join(__dirname, 'module.json'), buildPath);
 util.cp(path.join('./Tests', 'package.json'), path.join(buildPath, 'Tests'));
 util.cp(path.join('./Tests', 'package-lock.json'), path.join(buildPath, 'Tests'));
-util.cp('-r', 'openssl', buildPath);
+util.cp('-r', opensslDir, buildPath);
 util.cp('-r', 'Strings', buildPath);
 util.cp('-r', 'node_modules', buildPath);

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.262.1",
+    "version": "3.263.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-azure-arm-rest",
-            "version": "3.262.1",
+            "version": "3.263.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^3.4.2",

--- a/common-npm-packages/azure-arm-rest/package-lock.json
+++ b/common-npm-packages/azure-arm-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.263.0",
+    "version": "3.262.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-azure-arm-rest",
-            "version": "3.263.0",
+            "version": "3.262.1",
             "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^3.4.2",

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.262.1",
+    "version": "3.263.0",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",
@@ -38,6 +38,6 @@
         "typescript": "^4.9.5"
     },
     "scripts": {
-        "build": "node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/openssl/3.4.0/M252/openssl.zip ./openssl && node make.js"
+        "build": "node make.js"
     }
 }

--- a/common-npm-packages/azure-arm-rest/package.json
+++ b/common-npm-packages/azure-arm-rest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest",
-    "version": "3.263.0",
+    "version": "3.262.1",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",
@@ -38,6 +38,6 @@
         "typescript": "^4.9.5"
     },
     "scripts": {
-        "build": "node make.js"
+        "build": "node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/openssl/3.4.0/M252/openssl.zip ./openssl && node make.js"
     }
 }

--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.262.0",
+    "version": "2.263.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-docker-common",
-            "version": "2.262.0",
+            "version": "2.263.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/docker-common/package-lock.json
+++ b/common-npm-packages/docker-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.263.0",
+    "version": "2.263.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-docker-common",
-            "version": "2.263.0",
+            "version": "2.263.1",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",
@@ -14,7 +14,7 @@
                 "@types/q": "1.5.4",
                 "@types/uuid": "^8.3.0",
                 "azure-pipelines-task-lib": "^4.13.0",
-                "azure-pipelines-tasks-azure-arm-rest": "^3.262.0",
+                "azure-pipelines-tasks-azure-arm-rest": "^3.263.0",
                 "del": "2.2.0",
                 "q": "1.4.1"
             },
@@ -445,9 +445,9 @@
             }
         },
         "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-            "version": "3.262.0",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.262.0.tgz",
-            "integrity": "sha1-TGVipImr4VSCixzmyv3A/QD7qQw=",
+            "version": "3.263.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.263.0.tgz",
+            "integrity": "sha1-UOsMEorkX3/wsGmEEtjlfr85/CU=",
             "license": "MIT",
             "dependencies": {
                 "@azure/identity": "^3.4.2",
@@ -2012,9 +2012,9 @@
             }
         },
         "azure-pipelines-tasks-azure-arm-rest": {
-            "version": "3.262.0",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.262.0.tgz",
-            "integrity": "sha1-TGVipImr4VSCixzmyv3A/QD7qQw=",
+            "version": "3.263.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.263.0.tgz",
+            "integrity": "sha1-UOsMEorkX3/wsGmEEtjlfr85/CU=",
             "requires": {
                 "@azure/identity": "^3.4.2",
                 "@types/jsonwebtoken": "^8.5.8",

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.262.0",
+    "version": "2.263.0",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",

--- a/common-npm-packages/docker-common/package.json
+++ b/common-npm-packages/docker-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-docker-common",
-    "version": "2.263.0",
+    "version": "2.263.1",
     "description": "Common Library for Azure Rest Calls",
     "repository": {
         "type": "git",
@@ -19,7 +19,7 @@
         "@types/q": "1.5.4",
         "@types/uuid": "^8.3.0",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.262.0",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.263.0",
         "del": "2.2.0",
         "q": "1.4.1"
     },

--- a/common-npm-packages/java-common/java-common.ts
+++ b/common-npm-packages/java-common/java-common.ts
@@ -121,10 +121,19 @@ export function findJavaHome(jdkVersion: string, jdkArch: string): string {
 
     const jdkShortVersion: string = getShortJavaVersion(jdkVersion);
     const jdkMajorVersion: number = coerce(jdkShortVersion).major;
-    // jdkArchitecture is either x64 or x86
+    // jdkArchitecture is either x64, x86 or arm64
     // envName for version 1.7 and x64 would be "JAVA_HOME_7_X64"
-    var envName = "JAVA_HOME_" + jdkMajorVersion + "_" + jdkArch.toUpperCase();
-    let discoveredJavaHome = tl.getVariable(envName);
+    var envName: string;
+    let discoveredJavaHome: string;
+    if(jdkArch.toLowerCase() === 'arm64'){
+         // For arm64, we use a different environment variable naming convention
+         envName = "JAVA_HOME_" + jdkMajorVersion + "_" + jdkArch.toLowerCase();
+         discoveredJavaHome = process.env[envName];
+    } else {
+        envName = "JAVA_HOME_" + jdkMajorVersion + "_" + jdkArch.toUpperCase();
+        discoveredJavaHome = tl.getVariable(envName);
+    }
+
     if (!discoveredJavaHome) {
         if (isWindows) {
             discoveredJavaHome = readJavaHomeFromRegistry(jdkShortVersion, jdkArch);

--- a/common-npm-packages/java-common/package-lock.json
+++ b/common-npm-packages/java-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-java-common",
-    "version": "2.256.0",
+    "version": "2.263.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-java-common",
-            "version": "2.256.0",
+            "version": "2.263.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/java-common/package.json
+++ b/common-npm-packages/java-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-java-common",
-    "version": "2.256.0",
+    "version": "2.263.0",
     "description": "Azure Pipelines tasks Java Common",
     "main": "java-common.js",
     "scripts": {

--- a/common-npm-packages/kubernetes-common/helmutility.ts
+++ b/common-npm-packages/kubernetes-common/helmutility.ts
@@ -77,9 +77,12 @@ export async function getStableHelmVersion(): Promise<string> {
         responseArray.forEach(response => {
             if (response && response.tag_name) {
                 let currentHelmVerison = semver.clean(response.tag_name.toString());
-                if (currentHelmVerison) {
-                    if (currentHelmVerison.toString().indexOf('rc') == -1 && semver.gt(currentHelmVerison, latestHelmVersion)) {
-                        //If current helm version is not a pre release and is greater than latest helm version
+                 if (currentHelmVerison) {
+                        // Exclude any pre-release (alpha, beta, rc, etc.) and drafts.
+                        const isPreRelease = (response.prerelease === true) || !!semver.prerelease(currentHelmVerison);
+                        const isDraft = response.draft === true;
+                        if (!isPreRelease && !isDraft && semver.gt(currentHelmVerison, latestHelmVersion)) {
+                        // If current helm version is stable and greater than latest helm version
                         latestHelmVersion = currentHelmVerison;
                     }
                 }

--- a/common-npm-packages/securefiles-common/package-lock.json
+++ b/common-npm-packages/securefiles-common/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-pipelines-tasks-securefiles-common",
-    "version": "2.262.0",
+    "version": "2.263.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-pipelines-tasks-securefiles-common",
-            "version": "2.262.0",
+            "version": "2.263.0",
             "license": "MIT",
             "dependencies": {
                 "@types/mocha": "^5.2.7",

--- a/common-npm-packages/securefiles-common/package.json
+++ b/common-npm-packages/securefiles-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-securefiles-common",
-    "version": "2.262.0",
+    "version": "2.263.0",
     "description": "Azure Pipelines tasks SecureFiles Common",
     "main": "securefiles-common.js",
     "scripts": {


### PR DESCRIPTION
Fix getStableHelmVersion to avoid installing pre-release Helm versions (alpha/beta/rc).\n\nChanges:\n- Filter out GitHub prerelease and draft releases.\n- Also ignore semver pre-release tags via semver.prerelease.\n\nThis ensures HelmInstaller@1 with helmVersionToInstall: latest installs the latest stable (e.g., v3.18.x) and not v4 pre-releases.